### PR TITLE
Simpler globbing, jsx and fix glob confliction

### DIFF
--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -5,8 +5,8 @@ const scriptPath = resolvePackagePath();
 module.exports = {
   concurrent: false,
   linters: {
-    "**/*.+(js|json|less|css|ts|tsx|md)": [`npm run format`, "git add"],
-    "**/*.+(js|ts|tsx)": [
+    "*.{js,json,less,css,ts,tsx,md}": [`npm run format`, "git add"],
+    "*.{js,ts,tsx}": [
       `${scriptPath} lint`,
       `${scriptPath} test`,
       "git add",

--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -5,7 +5,7 @@ const scriptPath = resolvePackagePath();
 module.exports = {
   concurrent: false,
   linters: {
-    "*.{js,jsx,json,less,css,ts,tsx,md}": [`npm run format`, "git add"],
+    "*.{js,jsx,json,less,css,ts,tsx,md}": [`${scriptPath} format`, "git add"],
     "*.{js,jsx,ts,tsx}": [
       `${scriptPath} lint`,
       `${scriptPath} test`,

--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -5,8 +5,8 @@ const scriptPath = resolvePackagePath();
 module.exports = {
   concurrent: false,
   linters: {
-    "*.{js,json,less,css,ts,tsx,md}": [`npm run format`, "git add"],
-    "*.{js,ts,tsx}": [
+    "*.{js,jsx,json,less,css,ts,tsx,md}": [`npm run format`, "git add"],
+    "*.{js,jsx,ts,tsx}": [
       `${scriptPath} lint`,
       `${scriptPath} test`,
       "git add",


### PR DESCRIPTION
The important change which fixes the precommit formatting all files in bror is commit 
a1cc0c9. It seems if the package.json format script passes a glob as an argument, it takes precedence over the globs defined in the lint-staged config.